### PR TITLE
User biased matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
-# schmidtfutures
-Coding takehome for schmidt futures
+# User and Opportunity Matching
+Attempts to calculate reasonable matches given users with interests and opportunities with open roles.
+
+## Background and Motivations
+The idea of this project is to get a baseline match down which should then be manually reviewed. This matching problem is similar to the stable marriage problem which is notably solvable with the Gale-Shapley algorithm. The slight differences here make it hard to apply the algorithm exactly, but we can still take inspiration from it. 
+
+The notable differences are:
+- Opportunities can have multiple matches
+- There's no strict ranking that an opportunity would have for a given user/applicant
+
+This project assumes the users list their interests in order from most interested to least. The two core ideas behind this project is to:
+* Have the most matches possible
+* Give the user their top preference when possible
+
+The drawback of the current approach is that it starts with users and opportunites with least amount of interests and roles to ensure the most matches meaning it's biased towards those providing less info. If users and organizations knew about this they would be encouraged to include less interests and roles in order to get what they want.
+
+## Running the app
+This is a python 3 flask app which requires the Request and Flask module to start. I would recommend creating a virtual environment to do so which you can read more about [here](https://flask.palletsprojects.com/en/2.1.x/installation/#virtual-environments)
+
+To install the modules run:
+`pip install requests Flask`
+
+To run the service we need to set the environment variable for Flask and then run the app
+```
+export FLASK_APP=matcher_service
+flask run
+```
+The app should now be running on localhost:5000
+
+## Functionality
+`GET /matches` Returns a JSON list of all matches (a user object followed by an opportunity object)
+`GET /matches/users` Returns a JSON list of all matches grouped by user (effectively the same as /matches currently)
+`GET /matches/opportunites` Returns a JSON list of all matches grouped by opportunities
+`GET /matches/users/<user_id>` Returns a JSON of all matches for the given user_id integer
+`GET /matches/opportunities/<user_id>` Returns a JSON of all matches for the given opportunity_id integer
+`GET /matches/unmatched/users` Returns a JSON list of all remaining umatched users
+`GET /matches/unmatched/opportunities` Returns a JSON list of all remaining umatched opportunities
+
+## Later revisions
+Some ideas for improvements and nice to haves for future iterations would include:
+ - Database support
+ - Displaying a diff of what would change if the current matching is applied (roles left open, people left unmatched, etc)
+ - Support paging through the matches
+ - Allow for manual overrides i.e force certain matches and have the matcher recalculate around that
+ - Handle concurrency i.e allow two users to update things simultaneously 
+ - Handle more types of ranking and quotas i.e two spots may be open for one role, maybe the organizations could rank applicants in some way as well

--- a/data_loader.py
+++ b/data_loader.py
@@ -1,0 +1,18 @@
+import json
+import requests
+from user import User
+from opportunity import Opportunity
+
+class DataLoader(object):
+
+	def load_json_response_to_object(self, url, object):
+		resp = requests.get(url=url)
+		return json.loads(resp.text, object_hook=lambda data: object(**data))
+	
+
+	def get_users(self):
+		return self.load_json_response_to_object('https://raw.githubusercontent.com/schmidtfutures/sf-eng-challenge/main/users.json', User)
+
+
+	def get_opportunities(self):
+		return self.load_json_response_to_object('https://raw.githubusercontent.com/schmidtfutures/sf-eng-challenge/main/opportunities.json', Opportunity)

--- a/matcher.py
+++ b/matcher.py
@@ -1,0 +1,94 @@
+from collections import defaultdict, deque
+
+class Match(object):
+	def __init__(self, user, opportunity):
+		self.user = user
+		self.opportunity = opportunity
+
+# This class runs the matching algorithm and contains data to access said matches and unmatched users/opportunities as well
+# The matching algorithm relies on the opportunities not having a ranked preference for the user. This way, the first person to apply
+# will never be evicted. With this assumption the matcher sorts the users and opportunities by the least amount posted to avoid the possibility
+# of an opportunity being left open that could've been filled as the second choice for a user currently at their first choice. 
+
+# Note: with more time storing matches in a database would've been nice, but I think working in memory is good enough for now
+class Matcher(object):
+	def __init__(self):
+		self.users = []
+		self.opportunities = []
+		self._reset_match_vars()
+
+	def _reset_match_vars(self):
+		self.role_to_opportunity = defaultdict(list)
+		self.unmatched_users = None
+		self.unmatched_opportunities = None
+		self.match_by_user = {}
+		self.match_by_opportunity = defaultdict(list)
+		self.matches = []
+
+	def _generate_role_to_opportunity(self):
+		for opportunity in self.opportunities:
+			for role in opportunity.roles:
+				self.role_to_opportunity[role].append(opportunity)
+
+	def _attempt_to_match_user(self, user):
+		for role in user.interested_in:
+			opportunities = self.role_to_opportunity[role]
+			if not opportunities:
+				continue
+			# sort so we match unmatched first and hit the ones with less chance of being filled. Sort everytime since num matches may have changed
+			opportunities.sort(key=lambda opportunity: (len(self.match_by_opportunity[opportunity.id_]), opportunity.roles))
+			# Assumes roles only have headcount of 1
+			opportunity = opportunities.pop(0)
+			match = Match(user, opportunity)
+			self.match_by_user[user.id_] = match
+			self.match_by_opportunity[opportunity.id_].append(match)
+			# Users can only have one match so we don't have to loop through everything
+			return
+
+	def _calculate_unmatched_users(self):
+		self.unmatched_users = [user for user in self.users if user.id_ not in self.match_by_user.keys()]
+
+	def _calculate_unmatched_opportunities(self):
+		self.unmatched_opportunities = [opp for opp in self.opportunities if opp.id_ not in self.match_by_opportunity.keys()]
+
+
+	# Generates suggested matches by iterating through sorted users and opportunities. This will be 
+	# user biased since SF bets on people. Assumes interests are listed in order of preference. Prioritizes
+	# users with less preferences and opportunities with less roles to ensure there are no instances where 
+	# a potential match ends up missed. This unintentionally penalizes people/orgs that list more roles though
+	def match(self, users, opportunities):
+		self._reset_match_vars()
+		self.users = sorted(users, key=lambda user: len(user.interested_in))
+		self.opportunities = opportunities
+		self._generate_role_to_opportunity()
+		users_to_match = deque(self.users)
+		while users_to_match:
+			user = users_to_match.popleft()
+			self._attempt_to_match_user(user)
+		self.matches = list(self.match_by_user.values())
+		return self.matches
+
+	def get_matches(self):
+		return self.matches
+
+	def get_matches_by_user(self):
+		return self.matches
+
+	def get_matches_by_opportunities(self):
+		return list(self.match_by_opportunity.values())
+
+	def get_match_for_user(self, user_id):
+		return self.match_by_user[user_id]
+
+	def get_matches_for_opportunity(self, opportunity_id):
+		return self.match_by_opportunity[opportunity_id]
+
+	def get_unmatched_users(self):
+		if not self.unmatched_users:
+			self._calculate_unmatched_users()
+		return self.unmatched_users
+		
+	def get_unmatched_opportunities(self):
+		if not self.unmatched_opportunities:
+			self._calculate_unmatched_opportunities()
+		return self.unmatched_opportunities

--- a/matcher_service.py
+++ b/matcher_service.py
@@ -1,0 +1,55 @@
+from flask import Flask
+from matcher import Matcher
+from data_loader import DataLoader
+import json
+
+app = Flask(__name__)
+matcher = Matcher()
+
+@app.before_first_request
+def calculate_matches():
+	data_loader = DataLoader()
+	users = data_loader.get_users()
+	opportunities = data_loader.get_opportunities()
+	matcher.match(users, opportunities)
+
+@app.route("/matches")
+def matches():
+	all_matches = matcher.get_matches()
+	return json.dumps(all_matches, default=lambda o: o.__dict__)
+
+@app.route("/matches/users/")
+def match_by_user():
+	match_by_user = matcher.get_matches_by_user()
+	return json.dumps(match_by_user, default=lambda o: o.__dict__)
+
+@app.route("/matches/users/<user_id>")
+def match_by_user_id(user_id):
+	try:
+		match_for_user = matcher.get_match_for_user(int(user_id))
+	except:
+		return "User ID must be an integer", 400
+	return json.dumps(match_for_user, default=lambda o: o.__dict__)
+
+@app.route("/matches/opportunities/")
+def matches_by_opportunity():
+	matches_by_opportunity = matcher.get_matches_by_opportunities()
+	return json.dumps(matches_by_opportunity, default=lambda o: o.__dict__)
+
+@app.route("/matches/opportunities/<opportunity_id>")
+def match_by_opportunity_id(opportunity_id):
+	try: 
+		matches_for_opportuity = matcher.get_matches_for_opportunity(int(opportunity_id))
+	except:
+		return "Opportunity ID must be an integer", 400
+	return json.dumps(matches_for_opportuity, default=lambda o: o.__dict__)
+
+@app.route("/matches/unmatched/users")
+def unmatched_users():
+	unmatched_users = matcher.get_unmatched_users()
+	return json.dumps(unmatched_users, default=lambda o: o.__dict__)
+
+@app.route("/matches/unmatched/opportunities")
+def unmatched_opportunities():
+	unmatched_opportunities = matcher.get_unmatched_opportunities()
+	return json.dumps(unmatched_opportunities, default=lambda o: o.__dict__)

--- a/matcher_test.py
+++ b/matcher_test.py
@@ -1,0 +1,48 @@
+import unittest
+from user import User
+from opportunity import Opportunity
+from matcher import Matcher
+
+
+
+class MatcherTest(unittest.TestCase):
+	@classmethod
+	def setUpClass(self):
+		self.matcher = Matcher()
+
+	def test_it_returns_empty_before_matching(self):
+		matcher = Matcher()
+
+		assert len(matcher.get_unmatched_users()) == 0
+		assert len(matcher.get_unmatched_opportunities()) == 0
+
+	def test_it_returns_unmatched(self):
+		users = [User(1, "Peter", "Kung", "test@gmail.com", None)]
+		opportunities = [Opportunity(1, "Schmidt Futures", None, "sf@schmidtfutures.com")]
+
+		matches = self.matcher.match(users, opportunities)
+
+		self.assertEquals(self.matcher.get_unmatched_opportunities(), opportunities)
+		self.assertEquals(self.matcher.get_unmatched_users(), users)
+
+	def test_it_matches(self):
+		users = [User(1, "Peter", "Kung", "test@gmail.com", ["Software Engineer"])]
+		opportunities = [Opportunity(1, "Schmidt Futures", ["Software Engineer"], "sf@schmidtfutures.com")]
+
+		matches = self.matcher.match(users, opportunities)
+
+		assert len(matches) == 1
+		assert matches[0].user == users[0]
+		assert matches[0].opportunity == opportunities[0]
+
+	def test_it_matches_as_many_as_possible(self):
+		users = [User(1, "Peter", "Kung", "test@gmail.com", ["Astronaut", "Software Engineer"]), User(2, "John", "Doe", "jd@gmail.com", ["Astronaut"]), User(3, "Jane", "Doe", "jd1@gmail.com", ["Software Engineer"])]
+		opportunities = [Opportunity(1, "Space X", ["Astronaut"], "elon@musk.com"), Opportunity(2, "Schmidt Futures", ["Software Engineer"], "sf@schmidtfutures.com")]
+		
+		matches = self.matcher.match(users, opportunities)
+
+		assert len(matches) == 2
+		assert len(self.matcher.get_unmatched_users()) == 1
+
+if __name__ == '__main__':
+	unittest.main()

--- a/opportunity.py
+++ b/opportunity.py
@@ -1,0 +1,6 @@
+class Opportunity(object):
+	def __init__(self, id, organization, roles, email):
+		self.id_ = id
+		self.organization = organization
+		self.roles = [] if not roles else roles
+		self.email = email

--- a/user.py
+++ b/user.py
@@ -1,0 +1,7 @@
+class User(object):
+	def __init__(self, id, first_name, last_name, email, interested_in):
+		self.id_ = id
+		self.first_name = first_name
+		self.last_name = last_name
+		self.email = email
+		self.interested_in = [] if not interested_in else interested_in


### PR DESCRIPTION
Create matcher service with basic functionality

This PR introduces the matcher service supporting basic functionality including:
* viewing matches and unmatched users/opportunities
* viewing matches for a specific user or opportunity

The matcher algorithm works by sorting users by number of interests and running through and assigning them matches. Each interest/role is mapped to any opportunity with an opening. This list of opportunities is then sorted each time by number of applicants breaking ties with number of openings. Essentially, we match the most restrictive users first to the most restrictive opportunities first. This ensures we get the most number of matches.

Future work and thoughts are included in the README update of this PR